### PR TITLE
- changed the rendered elements layout

### DIFF
--- a/src/scss/modules/_pages.scss
+++ b/src/scss/modules/_pages.scss
@@ -1,5 +1,22 @@
 $max-height: 90vh;
-
+.pages {
+  &__container {
+    overflow: auto;
+    max-height: $page-size + 0vh;
+    height: 100%;
+    max-width: 100%;
+    width: 100%;
+    position: relative;
+    display: -webkit-inline-flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    justify-content: space-between;
+    @extend %border--strong--top;
+    @extend %border--strong--left;
+    @extend %border--strong--right;
+    border-radius: em(5) em(5) 0 0;
+  }
+}
 .page {
     overflow-y: hidden;
     overflow-x: auto;
@@ -8,31 +25,29 @@ $max-height: 90vh;
     width: 100%;
     max-width: 55em;
 
+
     &--multi {
         @extend %border--strong--left;
         @extend %border--strong--right;
     }
 
     &__container {
-        overflow: auto;
-        max-height: $page-size + 0vh;
-        height: 100%;
-        max-width: 100%;
-        width: 100%;
-        position: relative;
-        display: -webkit-inline-flex;
-        flex-direction: row;
-        flex-wrap: nowrap;
-        justify-content: space-between;
-        @extend %border--strong--top;
-        @extend %border--strong--left;
-        @extend %border--strong--right;
-        border-radius: em(5) em(5) 0 0;
+      display: grid;
+      @extend %themed-bg;
+      grid-template-columns: [col-start] [col-end];
+      grid-template-rows: [row-start] 5% [row-end] 95%;
+      grid-template-areas:
+        "image page-no"
+        "image text";
+      justify-items: stretch;
     }
 
     &__counter {
         grid-area: page-no;
         margin: em(10) 0 0 em(15);
+      text-align: right;
+      padding-right: em(15);
+      max-height: 5rem;
     }
 
     &__col {
@@ -58,15 +73,10 @@ $max-height: 90vh;
 }
 
 .paragraph {
+
     &__container {
-        display: grid;
-        @extend %themed-bg;
-        grid-template-columns: [col-start] [col-end];
-        grid-template-rows: [row-start] 25% [row-end] 75%;
-        grid-template-areas:
-            "page-no text"
-            "image text";
-        justify-items: stretch;
+      overflow-y: auto ;
+      padding-bottom: em(12);
     }
 }
 


### PR DESCRIPTION
 - to allow multiple paragraphs per page
 - to match the xml output from the RAS
 - move the page number above the text instead of the image
- Adjusted the scrolling
 - to move to the page of the current highlighted word
 - adjusted the layout so that scrolling is applied to the paragraph container therefore that text scrolls in-dependant of the image
- adjusted code to deal with multiple paragraphs per page

output published: https://unpkg.com/@deltork/readalong@0.0.7/dist/read-along.js