### PR TITLE
fix(assets): the lagecy behaviour, only images belong in assets/

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,14 +22,14 @@ you make to `/src` will be automatically shown in the browser.
 | `svgOverlay`      | `svg-overlay`       | Overlay This is an SVG overlay to place over the progress bar                                          | `string`                     | `undefined`    |
 | `text`            | `text`              | The text as TEI                                                                                        | `string`                     | `undefined`    |
 | `theme`           | `theme`             | Theme to use: ['light', 'dark'] defaults to 'dark'                                                     | `string`                     | `'light'`      |
-| `useAssetsFolder` | `use-assets-folder` | Toggle the use of assets folder for resolving image urls. Defaults to on for backwards compatibility   | `boolean`              | `true`         |
+| `useAssetsFolder` | `use-assets-folder` | Toggle the use of assets folder for resolving image urls. Defaults to 'true' for backwards compatibility   | `boolean`              | `true`         |
 
 
 #### IMAGES
 
 You have three options:
 
-* put images in "asests/" and provide relative link
+* put images in "assets/" and provide relative link
 * provide a full path
 * put it in a custom relative folder and make sure to add `use-assets-folder="false"` attribute to the read-long
   component

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ you make to `/src` will be automatically shown in the browser.
 | `svgOverlay`      | `svg-overlay`       | Overlay This is an SVG overlay to place over the progress bar                                          | `string`                     | `undefined`    |
 | `text`            | `text`              | The text as TEI                                                                                        | `string`                     | `undefined`    |
 | `theme`           | `theme`             | Theme to use: ['light', 'dark'] defaults to 'dark'                                                     | `string`                     | `'light'`      |
-| `useAssetsFolder` | `use-assets-folder` | Toggle the use of assets folder for resolving urls. Defaults to on to maintain backwards compatibility | `boolean`                    | `true`         |
+| `useAssetsFolder` | `use-assets-folder` | Toggle the use of assets folder for resolving image urls. Defaults to on for backwards compatibility   | `boolean`              | `true`         |
 
 
 #### IMAGES
@@ -121,18 +121,18 @@ the ```two-column-layout-page``` class for the page.
 ```
 ### Hide page number
 
-You hide the page number for any page by specifying the class ```hide-page-counter```
+You can hide the page number for any page by specifying the class ```hide-page-counter```.
 
 ## Assets folder
 
-By defaults all assets (img,text,audio) will be resolved to ```.\assets\``` relative to the index.html file. You can
+By defaults the image assets will be resolved to ```.\assets\``` relative to the index.html file. You can
 override this behaviour by using this attribute on the component ```use-assets-folder="false"```. The web component will
-not longer resolve url to the **assets** folder when this attribute is present
+not longer resolve url to the **assets** folder when this attribute is present.
 
 ## CSS customization
 
 You can override the default style of the component. This option is best used anyone does not want to clone this project
-and modify only the UI. Use the web inspector of your browser to find the classes you wish to override
+and modify only the UI. Use the web inspector of your browser to find the classes you wish to override.
 
 ```css
 /* change the font size and color of the text */

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,8 @@ You can either modify the `/src/index.html` or after running `npm start` you can
 the following script import in your own `index.html` page:
 
 ```html 
-    <script crossorigin="anonymous"   type="module" src='https://unpkg.com/@roedoejet/readalong@latest/dist/read-along/read-along.esm.js'></script>
+  <script type="module" src="https://unpkg.com/@roedoejet/readalong/dist/read-along/read-along.esm.js"></script>
+  <script nomodule src="https://unpkg.com/@roedoejet/readalong/dist/read-along/read-along.js"></script>
 ```
 
 Then, you can add as many read-along components to your page as you like simply by adding `<read-along></read-along>`

--- a/src/components/read-along-component/read-along.tsx
+++ b/src/components/read-along-component/read-along.tsx
@@ -685,11 +685,14 @@ export class ReadAlongComponent {
    * Using this Lifecycle hook to handle backwards compatibility of component attribute
    */
   componentWillLoad() {
+    // The backward compatible behaviour used to be audio, alignment and text files outside assets
+    // and only image files inside assets.
+    // See version 0.1.0, where it only looks in assets/ for images, nothing else.
     // TO maintain backwards compatibility handle assets url
-    this.audio = this.urlTransform(this.audio)
-    this.alignment = this.urlTransform(this.alignment)
-    this.text = this.urlTransform(this.text)
-    this.cssUrl = this.urlTransform(this.cssUrl)
+    //this.audio = this.urlTransform(this.audio)
+    //this.alignment = this.urlTransform(this.alignment)
+    //this.text = this.urlTransform(this.text)
+    //this.cssUrl = this.urlTransform(this.cssUrl)
 
     // TO maintain backwards compatibility language code
     if (this.language.length < 3) {


### PR DESCRIPTION
In 0.1.1, 0.1.0, 0.0.7 and older versions, only images got `assets/` added in front of the path provided. The smil, xml and audio files were loaded where specified. If they were in `assets/`, the paths in the `index.html` had to explicitly say that.

Thus, revert the default behaviour, i.e., the `useAssetsFolder=True` behaviour, to look for images in `assets/`, but not files directly linked from the html page.