### PR TITLE
Added tooltips for UI's buttons.

### DIFF
--- a/src/components/read-along-component/read-along.tsx
+++ b/src/components/read-along-component/read-along.tsx
@@ -1014,6 +1014,7 @@ export class ReadAlongComponent {
    */
 
   PlayControl = (): Element => <button data-cy="play-button" disabled={!this.isLoaded} aria-label="Play"
+                                       title="Play audio recording"
                                        onClick={() => {
                                          this.playing ? this.pause() : this.play()
                                        }}
@@ -1022,12 +1023,14 @@ export class ReadAlongComponent {
   </button>
 
   ReplayControl = (): Element => <button data-cy="replay-button" disabled={!this.isLoaded} aria-label="Rewind"
+                                         title="Replay audio recording"
                                          onClick={() => this.goBack(5)}
                                          class={"control-panel__control ripple theme--" + this.theme + " background--" + this.theme}>
     <i class="material-icons">replay_5</i>
   </button>
 
   StopControl = (): Element => <button data-cy="stop-button" disabled={!this.isLoaded} aria-label="Stop"
+                                       title="Stop audio recording"
                                        onClick={() => this.stop()}
                                        class={"control-panel__control ripple theme--" + this.theme + " background--" + this.theme}>
     <i class="material-icons">stop</i>
@@ -1041,16 +1044,19 @@ export class ReadAlongComponent {
   </div>
 
   StyleControl = (): Element => <button aria-label="Change theme" onClick={() => this.changeTheme()}
+                                        title="Change theme"
                                         class={"control-panel__control ripple theme--" + this.theme + " background--" + this.theme}>
     <i class="material-icons-outlined">style</i>
   </button>
 
   FullScreenControl = (): Element => <button aria-label="Full screen mode" onClick={() => this.toggleFullscreen()}
+                                             title="Full screen mode"
                                              class={"control-panel__control ripple theme--" + this.theme + " background--" + this.theme}>
     <i class="material-icons" aria-label="Full screen mode">{this.fullscreen ? 'fullscreen_exit' : 'fullscreen'}</i>
   </button>
 
   TextTranslationDisplayControl = (): Element => <button data-cy="translation-toggle" aria-label="Toggle Translation"
+                                                         title="Toggle translation"
                                                          onClick={() => this.toggleTextTranslation()}
                                                          class={"control-panel__control ripple theme--" + this.theme + " background--" + this.theme}>
     <i class="material-icons-outlined">subtitles</i>


### PR DESCRIPTION
For user's convenience and to provide them with a slightly better UI experience, I propose to add tooltips for all 6 UI buttons.  Note that the buttons already have the `@aria-label` but this isn't the same thing as `@title`.  
```
Accessible Rich Internet Applications (ARIA) defines ways to make Web content and Web applications (especially those developed with Ajax and JavaScript) more accessible to people with disabilities. For example, ARIA enables accessible navigation landmarks, JavaScript widgets, form hints and error messages, live content updates, and more.
```
With this in mind, I think it is still justified to add `@title` to the UI's buttons.

[What is the difference between aria-label and title attributes?](https://stackoverflow.com/questions/27953425/what-is-the-difference-between-aria-label-and-title-attributes)