### PR TITLE
Updating the documentation to say "use ^0.1.6"

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ Interactive story telling embeddable into any website!
 
 <!-- TODO: put an animated GIF here, showing it off! -->
 
+This mono repo combines two components:
+
+ - A [stencil web component](packages/stencil-component/) for visualizing read alongs,
+ - An [angular web component](packages/angular-workspace/) currently in development for editing them.
+
 For maintainers
 ---------------
 

--- a/packages/stencil-component/package-lock.json
+++ b/packages/stencil-component/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@roedoejet/readalong",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@roedoejet/readalong",
-            "version": "0.1.5",
+            "version": "0.1.6",
             "license": "MIT",
             "dependencies": {
                 "howler": "^2.2.3",

--- a/packages/stencil-component/readme.md
+++ b/packages/stencil-component/readme.md
@@ -40,8 +40,8 @@ You can either modify the `/src/index.html` or after running `npm start` you can
 the following script import in your own `index.html` page:
 
 ```html 
-  <script type="module" src="https://unpkg.com/@roedoejet/readalong/dist/read-along/read-along.esm.js"></script>
-  <script nomodule src="https://unpkg.com/@roedoejet/readalong/dist/read-along/read-along.js"></script>
+  <script type="module" src="https://unpkg.com/@roedoejet/readalong@^0.1.6/dist/read-along/read-along.esm.js"></script>
+  <script nomodule src="https://unpkg.com/@roedoejet/readalong@^0.1.6/dist/read-along/read-along.js"></script>
 ```
 
 Then, you can add as many read-along components to your page as you like simply by adding `<read-along></read-along>`
@@ -56,7 +56,7 @@ using _________ service located here: ____________.
 
 ## Loading as a single file
 
-By default, Stencil (the tool used to build this web component) uses lazy loading. However, some use cases for this web component might involve running the component as a single file, without access to the internet. A single-file script of this web component is therefore made available at https://unpkg.com/@roedoejet/readalong/dist/bundle.js although we recommend using the default imports using the unpkg content delivery network (cdn) described above.
+By default, Stencil (the tool used to build this web component) uses lazy loading. However, some use cases for this web component might involve running the component as a single file, without access to the internet. A single-file script of this web component is therefore made available at https://unpkg.com/@roedoejet/readalong@^0.1.6/dist/bundle.js although we recommend using the default imports using the unpkg content delivery network (cdn) described above.
 
 ## Theming
 


### PR DESCRIPTION
Also put pointers in the top-level readme of this mono-repo to the two components.