### PR TITLE
CI: matrix testing: test with Node 14 and Node 16

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -6,6 +6,8 @@ jobs:
       matrix:
         node_version: [14, 16, 18]
     runs-on: ubuntu-20.04
+    # Stop the occasional rogue instance before the 6h GitHub limit
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -2,15 +2,19 @@ name: End-to-end tests
 on: [push]
 jobs:
   cypress-run:
+    strategy:
+      matrix:
+        node_version: [14, 16, 18]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       # Install NPM dependencies, cache them correctly
       # and run all Cypress tests
-      - uses: actions/setup-node@v3
+      - name: Use Node.js ${{ matrix.node_version }}
+        uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: ${{ matrix.node_version }}
       - name: Cypress run
         uses: cypress-io/github-action@v4
         with:

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -4,7 +4,7 @@ jobs:
   cypress-run:
     strategy:
       matrix:
-        node_version: [14, 16, 18]
+        node_version: [14, 16]
     runs-on: ubuntu-20.04
     # Stop the occasional rogue instance before the 6h GitHub limit
     timeout-minutes: 15

--- a/packages/stencil-component/src/scss/utilities/_functions.scss
+++ b/packages/stencil-component/src/scss/utilities/_functions.scss
@@ -1,5 +1,7 @@
 // Functions
 
+@use "sass:math";
+
 // Unit Conversion
 
 // strip-unit($num)
@@ -32,7 +34,7 @@
       $context: strip-units($context);
     }
     @if $target == 0 { @return 0 }
-    @return $target / $context + 0em;
+    @return math.div($target, $context) + 0em;
   }
   // rem()
   //
@@ -52,7 +54,7 @@
       $context: strip-units($context);
     }
     @if $target == 0 { @return 0 }
-    @return $target / $context + 0rem;
+    @return math.div($target, $context) + 0rem;
   }
   
   // px()


### PR DESCRIPTION
end-to-end-tests.yml doesn't pass with Node 18 at the moment, but it does with Node 14 and Node 16, two currently supported LTS versions, so we should test on those systematically in CI.