### PR TITLE
fix: display error when audio cannot load

### DIFF
--- a/packages/web-component/cypress/e2e/missing.assets.feedback.cy.js
+++ b/packages/web-component/cypress/e2e/missing.assets.feedback.cy.js
@@ -34,7 +34,6 @@ context("Readalong Component with missing assets", () => {
 
     cy.readalong().within(() => {
       cy.contains("Page");
-      return; // TODO fix this test case and then reactivate it
       cy.get("[data-cy=audio-error]").should(($el) => {
         expect($el.hasClass("fade")).equal(false)
         //check that message is visible

--- a/packages/web-component/src/components/read-along-component/read-along.tsx
+++ b/packages/web-component/src/components/read-along-component/read-along.tsx
@@ -754,8 +754,8 @@ export class ReadAlongComponent {
     this.audio_howl_sprites = new Howl({
       src: [this.audio],
       preload: false,
-      // onloaderror: this.audioFailedToLoad.bind(this),
-      // onload: this.audioLoaded.bind(this)
+      onloaderror: this.audioFailedToLoad.bind(this),
+      onload: this.audioLoaded.bind(this)
 
     })
     // Once loaded, get duration and build Sprite


### PR DESCRIPTION
We defer the audio loading, but we still need to display an error on failure, and recognize success on successful load.