### PR TITLE
Enable CORS headers for serve-test-data and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ Note that you will need to also spin-up the ReadAlong-Studio API in order to hav
 
 then run:
 
-    PRODUCTION= uvicorn readalongs.web_api:web_api_app --reload     
+    DEVELOPMENT=1 uvicorn readalongs.web_api:web_api_app --reload     
 
 If your Studio sandbox is in a sibling directory to this sandbox, and you Python environment is active, `nx serve-web-api studio-web` will run that command for you.
 
-Studio-Web will automatically [publish](.github/workflows/publish.yml) to https://readalong-studio.mothertongues.org/ every time there is a change to `main`. Note that you will need to have CORS enabled through an extension like [this one](https://chrome.google.com/webstore/detail/allow-cors-access-control/lhobafahddgcelffkeicbaginigeejlf?hl=en) in order to have the requests between Studio-Web and the API work. You will not be able to test against the prodution ReadAlongs Studio API because of the CORS protections.
+Studio-Web will automatically [publish](.github/workflows/publish.yml) to https://readalong-studio.mothertongues.org/ every time there is a change to `main`.
 
 #### Understanding where the components come from when you run locally
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Note that you will need to also spin-up the ReadAlong-Studio API in order to hav
 
 then run:
 
-    DEVELOPMENT=1 uvicorn readalongs.web_api:web_api_app --reload     
+    DEVELOPMENT=1 uvicorn readalongs.web_api:web_api_app --reload
 
 If your Studio sandbox is in a sibling directory to this sandbox, and you Python environment is active, `nx serve-web-api studio-web` will run that command for you.
 
@@ -103,7 +103,10 @@ to serve or import. In the instructions above, we actually show two methods you 
 
 In three different terminal windows:
 
-Make sure this command is serving the web-component on port 3333:
+Make sure this command is serving the web-component on port 3333 (if
+it launches on a different port, you will have to kill the currently
+running process using that port, whose PID you can find with `fuser -n
+tcp 3333`):
 
     nx serve web-component
 

--- a/packages/studio-web/README.md
+++ b/packages/studio-web/README.md
@@ -47,7 +47,7 @@ Run `npm start` or `ng serve` for a dev server. Navigate to `http://localhost:42
 
 To see the French version you may run `ng serve --configuration=fr`. Other translations are always welcome!
 
-The ReadAlongs/Studio web API must also be running locally on port 8000 for the app to work in dev mode: clone https://github.com/ReadAlongs/Studio.git, cd into `Studio/readalongs` and launch the web API with `PRODUCTION= uvicorn readalongs.web_api:web_api_app --reload` (see `Studio/readalongs/web_api.py` for details).
+The ReadAlongs/Studio web API must also be running locally on port 8000 for the app to work in dev mode: clone https://github.com/ReadAlongs/Studio.git, cd into `Studio/readalongs` and launch the web API with `DEVELOPMENT=1 uvicorn readalongs.web_api:web_api_app --reload` (see `Studio/readalongs/web_api.py` for details).
 
 ### Production
 

--- a/packages/web-component/package.json
+++ b/packages/web-component/package.json
@@ -24,7 +24,7 @@
         "test-servers": "bash ./bin/run-test-servers",
         "test:once": "cypress run",
         "test:open": "cypress open",
-        "serve-test-data": "sirv --dev --port 5000 test-data/",
+        "serve-test-data": "sirv --dev --cors --port 5000 test-data/",
         "generate": "stencil generate",
         "wait-for-test-server": "wait-on -i 2000 -v -t 30000 http://localhost:3333/build/web-component.esm.js"
     },


### PR DESCRIPTION
No longer need to use the CORS extension, and the environment variable (see https://github.com/ReadAlongs/Studio/pull/147) has changed for the studio server.